### PR TITLE
dependency refresh and restructuring

### DIFF
--- a/deploy/training.py
+++ b/deploy/training.py
@@ -13,18 +13,11 @@ import shutil
 import logging
 import argparse
 
-from azureml.core import Workspace, Experiment, Model
+from azureml.core import Experiment
 from azureml.train.dnn import PyTorch
 from azureml.train.estimator import Estimator
 from azureml.core.compute import ComputeTarget, AmlCompute
 from azureml.core.compute_target import ComputeTargetException
-from azureml.train.hyperdrive import  (BayesianParameterSampling, RandomParameterSampling,
-                                        HyperDriveConfig, PrimaryMetricGoal,
-                                        choice, uniform, loguniform)
-
-from azureml.core.authentication import InteractiveLoginAuthentication
-from azureml.core.model import InferenceConfig
-from azureml.exceptions import WebserviceException
 
 # Custom Functions
 import sys 
@@ -73,7 +66,7 @@ except ComputeTargetException:
     compute_target.wait_for_completion(show_output=True)
 
 # Python dependencies
-pip_packages=he.get_requirements(req_type='train')
+pip_packages = he.get_requirements(req_type='train')
 
 ## Local Config
 fn_config_infer = 'config.json'
@@ -177,5 +170,5 @@ if args.do_train:
 #####  CLEANUP
 ############################################
 
-#Remove temp config
+# Remove temp config
 os.remove(f'./src/{fn_config_infer}')

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,15 +18,8 @@ astroid==2.4.2
 atomicwrites==1.4.0
 adal==1.2.4
 attrs==20.1.0
-azure-ai-textanalytics==1.0.0b3 #TO BE UPGRADED -> 5.0.0
-gensim==3.8.0
-spacy==2.3.2 
 transformers==3.0.2 
-farm==0.4.7
-flair==0.6
 fsspec==0.8.0
-selenium==3.141.0
-bs4==0.0.1
 boto3==1.14.54
 scipy>=1.3.2
 sklearn
@@ -36,6 +29,17 @@ PyJWT==1.7.1
 pyyml==0.0.2
 opencensus==0.7
 opencensus-ext-azure==1
+##SCRAPER ONLY
+selenium==3.141.0
+bs4==0.0.
+##OPTIONAL LOCAL
+azure-ai-textanalytics==1.0.0b3 #TO BE UPGRADED -> 5.0.0 -> TA
+gensim==3.8.0
+spacy==2.3.2 
+farm==0.4.7
+flair==0.6
+torch==1.5.1+cpu 
+torchvision==0.6.1+cpu
 ##DEPLOY ONLY
 azure-keyvault==1.1.0
 azure-identity==1.2.0
@@ -48,5 +52,5 @@ flake8==3.8.3
 ipykernel==5.3.4
 streamlit
 tqdm==4.48.2
-torch==1.5.1+cpu 
-torchvision==0.6.1+cpu
+
+

--- a/src/helper.py
+++ b/src/helper.py
@@ -10,11 +10,7 @@ import platform
 import configparser
 from pathlib import Path
 import pandas as pd
-import re
 import json
-import yaml
-import spacy
-from flair.models import SequenceTagger
 
 try:
     from azure.common.credentials import ServicePrincipalCredentials
@@ -92,6 +88,7 @@ def get_repo_dir():
     return root_dir
 
 def get_project_config(fn):
+    """Load project configration from repository directory and parse it"""
     _fn1 = f"{get_repo_dir()}/project/{fn}"
     _fn2 = f"{get_repo_dir()}/src/config.json"
     if os.path.isfile(_fn1):
@@ -266,36 +263,6 @@ farm_model_lookup = {
     }
 }
 
-def get_farm_model(model_type, language):
-    ml = None
-    mt = farm_model_lookup.get(model_type)
-    if mt is not None:
-        ml = mt.get(language)
-    if ml is None:
-        ml = mt.get('xx')
-    if ml is None:
-        raise Exception(f'No Transformer/FARM model found. model = {model_type}, lang = {language}')
-    return ml
-
-spacy_model_lookup = {
-    'en':'en_core_web_sm',
-    'de':'de_core_news_sm',
-    'fr':'fr_core_news_sm',
-    'es':'es_core_news_sm',
-    'it':'it_core_news_sm',
-    'xx':'xx_ent_wiki_sm'
-}
-
-def load_spacy_model(language='xx', disable=[]):
-    try:
-        nlp = spacy.load(spacy_model_lookup[language], disable=disable)
-    except OSError:
-        logging.warning(f'[INFO] Downloading spacy language model for {language}')
-        from spacy.cli import download
-        download(spacy_model_lookup[language])
-        nlp = spacy.load(spacy_model_lookup[language], disable=disable)
-    return nlp
-
 flair_model_lookup = {
     'en' : 'ner-ontonotes-fast', 
     'de' : 'ner-multi-fast',
@@ -317,16 +284,17 @@ def get_flair_model(language, object_type):
         m = lookup.get('xx')
     return m
 
-def load_flair_model(path=None, language='xx', task='ner'):
-    if task == 'ner':
-        # if path is None:
-        model = SequenceTagger.load(get_flair_model(language, 'model'))
-        # else:
-            # model = SequenceTagger.load(path)
-    else:
-        logging.warning(f'FLAIR MODEL TASK NOT SUPPORTED --> {task}')
-        model = None
-    return model
+def get_farm_model(model_type, language):
+    ml = None
+    mt = farm_model_lookup.get(model_type)
+    if mt is not None:
+        ml = mt.get(language)
+    if ml is None:
+        ml = mt.get('xx')
+    if ml is None:
+        raise Exception(f'No Transformer/FARM model found. model = {model_type}, lang = {language}')
+    return ml
+
 
 ############################################
 #####   Dataframe

--- a/src/ner.py
+++ b/src/ner.py
@@ -5,10 +5,12 @@ import logging
 import requests
 import os
 
+import spacy
 from spacy.matcher import PhraseMatcher
 from spacy.tokens import Span
 
 from flair.data import Sentence
+from flair.models import SequenceTagger
 
 from farm.data_handler.data_silo import DataSilo
 from farm.data_handler.processor import NERProcessor
@@ -28,6 +30,38 @@ import custom as cu
 import data as dt
 import helper as he
 
+
+spacy_model_lookup = {
+    'en':'en_core_web_sm',
+    'de':'de_core_news_sm',
+    'fr':'fr_core_news_sm',
+    'es':'es_core_news_sm',
+    'it':'it_core_news_sm',
+    'xx':'xx_ent_wiki_sm'
+}
+
+def load_spacy_model(language='xx', disable=[]):
+    """Load spacy models depending on language"""
+    try:
+        nlp = spacy.load(spacy_model_lookup[language], disable=disable)
+    except OSError:
+        logging.warning(f'[INFO] Downloading spacy language model for {language}')
+        from spacy.cli import download
+        download(spacy_model_lookup[language])
+        nlp = spacy.load(spacy_model_lookup[language], disable=disable)
+    return nlp
+
+def load_flair_model(path=None, language='xx', task='ner'):
+    """Load flair models depending on language"""
+    if task == 'ner':
+        # if path is None:
+        model = SequenceTagger.load(he.get_flair_model(language, 'model'))
+        # else:
+            # model = SequenceTagger.load(path)
+    else:
+        logging.warning(f'FLAIR MODEL TASK NOT SUPPORTED --> {task}')
+        model = None
+    return model
 
 # Custom FLAIR element for spacy pipeline
 class FlairMatcher(object):


### PR DESCRIPTION
we faced the issue that large dependencies such as torch, flair, farm etc. are loaded when running the deploy/training.py entry script. in many use cases, it requires too much local space to install all of the dependencies. thus, we moved some dependencies to the model where they are actually needed (such as ner) and therefore only installed on the local compute.
the solution can still be fully ran locally.